### PR TITLE
Return floats instead of int for more precise measurements

### DIFF
--- a/src/LOLIN_HP303B.h
+++ b/src/LOLIN_HP303B.h
@@ -34,21 +34,21 @@ public:
   int16_t standby(void);
 
   //Command Mode
-  int16_t measureTempOnce(int32_t &result);
-  int16_t measureTempOnce(int32_t &result, uint8_t oversamplingRate);
+  int16_t measureTempOnce(float &result);
+  int16_t measureTempOnce(float &result, uint8_t oversamplingRate);
   int16_t startMeasureTempOnce(void);
   int16_t startMeasureTempOnce(uint8_t oversamplingRate);
-  int16_t measurePressureOnce(int32_t &result);
-  int16_t measurePressureOnce(int32_t &result, uint8_t oversamplingRate);
+  int16_t measurePressureOnce(float &result);
+  int16_t measurePressureOnce(float &result, uint8_t oversamplingRate);
   int16_t startMeasurePressureOnce(void);
   int16_t startMeasurePressureOnce(uint8_t oversamplingRate);
-  int16_t getSingleResult(int32_t &result);
+  int16_t getSingleResult(float &result);
 
   //Background Mode
   int16_t startMeasureTempCont(uint8_t measureRate, uint8_t oversamplingRate);
   int16_t startMeasurePressureCont(uint8_t measureRate, uint8_t oversamplingRate);
   int16_t startMeasureBothCont(uint8_t tempMr, uint8_t tempOsr, uint8_t prsMr, uint8_t prsOsr);
-  int16_t getContResults(int32_t *tempBuffer, uint8_t &tempCount, int32_t *prsBuffer, uint8_t &prsCount);
+  int16_t getContResults(float *tempBuffer, uint8_t &tempCount, float *prsBuffer, uint8_t &prsCount);
 
   //Interrupt Control
   int16_t setInterruptPolarity(uint8_t polarity);
@@ -122,11 +122,11 @@ private:
   int16_t configTemp(uint8_t temp_mr, uint8_t temp_osr);
   int16_t configPressure(uint8_t prs_mr, uint8_t prs_osr);
   uint16_t calcBusyTime(uint16_t temp_rate, uint16_t temp_osr);
-  int16_t getTemp(int32_t *result);
-  int16_t getPressure(int32_t *result);
-  int16_t getFIFOvalue(int32_t *value);
-  int32_t calcTemp(int32_t raw);
-  int32_t calcPressure(int32_t raw);
+  int16_t getTemp(float *result);
+  int16_t getPressure(float *result);
+  int16_t getFIFOvalue(float *value);
+  float calcTemp(float raw);
+  float calcPressure(float raw);
 
   //bus specific
   int16_t readByte(uint8_t regAddress);


### PR DESCRIPTION
I modified the library to return float values instead of int32.